### PR TITLE
Page numbers set to .5 IN

### DIFF
--- a/Page_Number_fix
+++ b/Page_Number_fix
@@ -38,6 +38,7 @@ document-settings {
 area-header {
 	content: page-number
 	text-alignment: right
+	top-spacing: 0.5in
 }
 
 //


### PR DESCRIPTION
As per MLA guidelines at https://owl.purdue.edu/owl/purdue_owl.html, the page numbers should be set to half an inch.

![Screen Shot 2019-07-25 at 9 06 49 AM](https://user-images.githubusercontent.com/35087175/61877131-5edae800-aebc-11e9-9ddc-797dbce8eca9.png)
![Screen Shot 2019-07-25 at 9 23 21 AM](https://user-images.githubusercontent.com/35087175/61878008-2b00c200-aebe-11e9-9eb6-08c1d2b07540.png)
![Screen Shot 2019-07-25 at 9 24 25 AM](https://user-images.githubusercontent.com/35087175/61878009-2d631c00-aebe-11e9-8e8d-db5d10ca3f00.png)


